### PR TITLE
test: verify dashboard and API message

### DIFF
--- a/achernar-frontend/src/App.test.js
+++ b/achernar-frontend/src/App.test.js
@@ -1,8 +1,24 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve({ message: 'Hello from API' }),
+    }),
+  );
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('renders dashboard heading and API message', async () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+
+  expect(screen.getByText(/Achernar Dashboard \(MVP\)/i)).toBeInTheDocument();
+
+  await waitFor(() =>
+    expect(screen.getByText(/Hello from API/i)).toBeInTheDocument()
+  );
 });


### PR DESCRIPTION
## Summary
- add React test that renders `<App />`
- mock `fetch` and assert dashboard heading and API message

## Testing
- `cd achernar-frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68900cb376c88332bc2e3bcc1a45ca67