### PR TITLE
Fix JSON suffix handling in Hello endpoint

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,15 @@
 from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+from rest_framework import status
 
-# Create your tests here.
+
+class HelloViewTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_json_suffix_returns_message(self):
+        url = reverse('hello').rstrip('/') + '.json'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"message": "Hello from Achernar Django API!"})

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,6 +1,9 @@
 from django.urls import path
+from rest_framework.urlpatterns import format_suffix_patterns
 from .views import HelloView
 
 urlpatterns = [
-    path('hello/', HelloView.as_view()),
+    path('hello/', HelloView.as_view(), name='hello'),
 ]
+
+urlpatterns = format_suffix_patterns(urlpatterns)

--- a/core/views.py
+++ b/core/views.py
@@ -2,5 +2,5 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 
 class HelloView(APIView):
-    def get(self, request):
+    def get(self, request, format=None):
         return Response({"message": "Hello from Achernar Django API!"})


### PR DESCRIPTION
## Summary
- allow Hello endpoint to accept format suffixes
- cover the format suffix with a regression test

## Testing
- `PYTHONPATH=venv/Lib/site-packages python3 manage.py test core`

------
https://chatgpt.com/codex/tasks/task_e_68900bb696048332b911c6d77e191140