### PR TITLE
Implement user dashboard with equipment cards

### DIFF
--- a/achernar-frontend/src/App.js
+++ b/achernar-frontend/src/App.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import Dashboard from './pages/Dashboard';
 
 function App() {
   const [apiMessage, setApiMessage] = useState('');
@@ -15,7 +16,7 @@ function App() {
       <div style={{ margin: '2rem 0' }}>
         <strong>Django API says:</strong> {apiMessage}
       </div>
-      {/* Add more dashboard features here */}
+      <Dashboard />
     </div>
   );
 }

--- a/achernar-frontend/src/components/EquipmentCard.js
+++ b/achernar-frontend/src/components/EquipmentCard.js
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+
+function EquipmentCard() {
+  const [equipment, setEquipment] = useState(null);
+
+  useEffect(() => {
+    fetch('http://localhost:8000/api/equipment/')
+      .then((res) => res.json())
+      .then((data) => setEquipment(data))
+      .catch(() =>
+        setEquipment({
+          mount: 'Unknown mount',
+          camera: 'Unknown camera',
+          filter_wheel: 'Unknown',
+        })
+      );
+  }, []);
+
+  if (!equipment) {
+    return <div className="card">Loading equipment...</div>;
+  }
+
+  return (
+    <div className="card">
+      <h3>Your Equipment</h3>
+      <ul>
+        <li>Mount: {equipment.mount}</li>
+        <li>Camera: {equipment.camera}</li>
+        <li>Filter Wheel: {equipment.filter_wheel}</li>
+      </ul>
+    </div>
+  );
+}
+
+export default EquipmentCard;

--- a/achernar-frontend/src/components/UserCard.js
+++ b/achernar-frontend/src/components/UserCard.js
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+
+function UserCard() {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    fetch('http://localhost:8000/api/user/')
+      .then((res) => res.json())
+      .then((data) => setUser(data))
+      .catch(() => setUser({ username: 'anonymous', email: 'unknown' }));
+  }, []);
+
+  if (!user) {
+    return <div className="card">Loading user...</div>;
+  }
+
+  return (
+    <div className="card">
+      <h2>{user.username}</h2>
+      <p>{user.email}</p>
+    </div>
+  );
+}
+
+export default UserCard;

--- a/achernar-frontend/src/index.css
+++ b/achernar-frontend/src/index.css
@@ -11,3 +11,12 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.card {
+  background: #1f1f23;
+  border: 1px solid #2a2a2e;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  color: #e4e4e7;
+}

--- a/achernar-frontend/src/pages/Dashboard.js
+++ b/achernar-frontend/src/pages/Dashboard.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import UserCard from '../components/UserCard';
+import EquipmentCard from '../components/EquipmentCard';
+
+function Dashboard() {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+        gap: '1rem',
+      }}
+    >
+      <UserCard />
+      <EquipmentCard />
+    </div>
+  );
+}
+
+export default Dashboard;


### PR DESCRIPTION
## Summary
- remove prior Tauri desktop scaffolding
- add user and equipment cards to dashboard and style shared card component

## Testing
- `CI=true npm test --prefix achernar-frontend`
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68900f7710d08332bb6c121554ebfb8f